### PR TITLE
Normalized Scores to be from 0 -> 1

### DIFF
--- a/FuzzyMatching/FuzzyMatching.Core/Services/RuntimeClient.cs
+++ b/FuzzyMatching/FuzzyMatching.Core/Services/RuntimeClient.cs
@@ -1,6 +1,7 @@
 ﻿using FuzzyMatching.Core.Utilities.FeatureMatrixArithmetics;
 using FuzzyMatching.Core.Utilities.MatrixArithmetics;
 using FuzzyMatching.Core.Utilities.MatrixOperations;
+using FuzzyMatching.Core.Utilities.Normalizers;
 using FuzzyMatching.Definitions.Models;
 using FuzzyMatching.Definitions.Services;
 using System.Collections.Generic;
@@ -34,11 +35,14 @@ namespace FuzzyMatching.Core.Services
             float minValue = similarityValues.Min();
             int minIndex = similarityValues.ToList().IndexOf(minValue);
 
+            // normalize cosine similarity to 0 - 1 score
+            float normalizedScore = Normalizer.NormalizeSimilarity(minValue);
+
             // return
             return new MatchingResult
             {
                 MatchingIndex = minIndex,
-                MatchingScore = minValue,
+                MatchingScore = normalizedScore,
                 ClosestSentence = Dataset[minIndex]
             };
         }

--- a/FuzzyMatching/FuzzyMatching.Core/Utilities/Normalizers/Normalizer.cs
+++ b/FuzzyMatching/FuzzyMatching.Core/Utilities/Normalizers/Normalizer.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FuzzyMatching.Core.Utilities.Normalizers
+{
+    public static class Normalizer
+    {
+        public static float NormalizeSimilarity(float similarity)
+        {
+            //Happens when sentenceToMatch is an empty string
+            if(float.IsNaN(similarity) || float.IsPositiveInfinity(similarity))
+            {
+                return 0;
+            }
+
+            //perfect match threshold
+            if (Math.Abs(similarity - 1f) < 0.0001f)
+                return 1;
+
+
+            var exp = Math.Pow(Math.E, 2f*similarity-4.5);
+            var score = -exp / (1 + exp) + 1;
+            
+            
+            return (float)score;
+        }
+    }
+}


### PR DESCRIPTION
Normalized score by doing two things:

- Setting a threshold for perfect matching
- Applying the following function to Normalize the rest of the values based on values seen with test cases.

![image](https://user-images.githubusercontent.com/41678585/127913307-3c4c1dfd-2634-472d-a6a7-922c811b9e56.png)

The results of the normalization on a few samples are as follows:

**Input Statement** --> **Matched Statement** --> **Score**
"ambitious olsson win triple jump"  --> "ambitious olsson wins triple jump"--> 0.92
"ambitious olsson wins double jump" --> "ambitious olsson wins triple jump"--> 0.89
"boring olsson loses double jump" -->  "ambitious olsson wins triple jump" --> 0.69
"some random garbage" --> "man survives garbage truck crush" --> 0.25